### PR TITLE
Update task and .jshintrc in order to support the new jSmart release

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,8 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "globals"   : {
-    "jSmart": false
-  }
+  "node": true
 }

--- a/tasks/jsmart.js
+++ b/tasks/jsmart.js
@@ -8,8 +8,8 @@
 
 'use strict';
 
-require('jsmart');
-var path = require('path'),
+var jSmart = require('jsmart').jSmart,
+    path = require('path'),
     strcase = require('tower-strcase');
 
 module.exports = function(grunt) {


### PR DESCRIPTION
Pull request created in order to accommodate changes on [Avcajaraville/jsmart](https://github.com/Avcajaraville/jsmart).

These changes are:
- Add UMD, CommonJS & web/browser support. Based on [this pull request](umakantp#14).
- Remove **String.prototype.fetch** function (since this is a very bad practice), and instead, modifying the export of the module. Now it exports the constructor and the fetch function.
- The module now exports the following object: `{ jSmart: jSmart, fetch: fetch }`. This is, `jSmart` constructor and `fecth` function

Test passing.
